### PR TITLE
Fix PR for Core S 32 GB

### DIFF
--- a/revpi-hat-PR100361R01.json
+++ b/revpi-hat-PR100361R01.json
@@ -2,7 +2,7 @@
     "version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core S 32GB",
-    "pid": 351,
+    "pid": 361,
     "prev": 1,
     "pver": 101,
     "dtstr": "revpi-core-s-2022",


### PR DESCRIPTION
Core S 32 GB has product id PR100361 and not PR100351.