### PR TITLE
Remove unused variable "pr"

### DIFF
--- a/update-readme.py
+++ b/update-readme.py
@@ -21,8 +21,6 @@ for template in revpi_hat_templates:
         product_revision = template_data["prev"]
         overlay = template_data["dtstr"]
 
-        pr = f"PR{product_id}R{product_revision:02}"
-
         readme += f"| [{name }]({template}) | PR{product_id} | R{product_revision:02} | {overlay} |\n"
 
 


### PR DESCRIPTION
Variable "pr" is not necessary and is therefore removed from the script.

Signed-off-by: Ramiro Gsponer <r.gsponer@kunbus.com>