### PR TITLE
Add eeprom_data_version to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Device specific JSON templates for RevPi HAT EEPROM generation
 
-| Device | Product Id | Product Revision | Devicetree Overlay |
-| ------ | ---------- | ---------------- | ------------------ |
-| [RevPi Core 3+ 8GB](./revpi-hat-PR100299R01.json) | PR100299 | R01 | revpi-core-2022 |
-| [RevPi Core 3+ 16GB](./revpi-hat-PR100300R01.json) | PR100300 | R01 | revpi-core-2022 |
-| [RevPi Core 3+ 32GB](./revpi-hat-PR100301R01.json) | PR100301 | R01 | revpi-core-2022 |
-| [RevPi Flat](./revpi-hat-PR100328R03.json) | PR100328 | R03 | revpi-flat-s-2022 |
-| [RevPi Core S 8GB](./revpi-hat-PR100359R01.json) | PR100359 | R01 | revpi-core-s-2022 |
-| [RevPi Core S 16GB](./revpi-hat-PR100360R01.json) | PR100360 | R01 | revpi-core-s-2022 |
-| [RevPi Core S 32GB](./revpi-hat-PR100361R01.json) | PR100361 | R01 | revpi-core-s-2022 |
-| [RevPi Core SE 8GB](./revpi-hat-PR100365R00.json) | PR100365 | R00 | revpi-core-se-2022 |
-| [RevPi Core SE 16GB](./revpi-hat-PR100366R00.json) | PR100366 | R00 | revpi-core-se-2022 |
-| [RevPi Core SE 32GB](./revpi-hat-PR100367R00.json) | PR100367 | R00 | revpi-core-se-2022 |
+| Device | Product Id | Product Revision | Data Version | Devicetree Overlay |
+| ------ | ---------- | ---------------- | ------------ | ------------------ |
+| [RevPi Core 3+ 8GB](./revpi-hat-PR100299R01.json) | PR100299 | R01 | 1 | revpi-core-2022 |
+| [RevPi Core 3+ 16GB](./revpi-hat-PR100300R01.json) | PR100300 | R01 | 1 | revpi-core-2022 |
+| [RevPi Core 3+ 32GB](./revpi-hat-PR100301R01.json) | PR100301 | R01 | 1 | revpi-core-2022 |
+| [RevPi Flat](./revpi-hat-PR100328R03.json) | PR100328 | R03 | 0 | revpi-flat-s-2022 |
+| [RevPi Core S 8GB](./revpi-hat-PR100359R01.json) | PR100359 | R01 | 1 | revpi-core-s-2022 |
+| [RevPi Core S 16GB](./revpi-hat-PR100360R01.json) | PR100360 | R01 | 1 | revpi-core-s-2022 |
+| [RevPi Core S 32GB](./revpi-hat-PR100361R01.json) | PR100361 | R01 | 1 | revpi-core-s-2022 |
+| [RevPi Core SE 8GB](./revpi-hat-PR100365R00.json) | PR100365 | R00 | 1 | revpi-core-se-2022 |
+| [RevPi Core SE 16GB](./revpi-hat-PR100366R00.json) | PR100366 | R00 | 1 | revpi-core-se-2022 |
+| [RevPi Core SE 32GB](./revpi-hat-PR100367R00.json) | PR100367 | R00 | 1 | revpi-core-se-2022 |

--- a/revpi-hat-PR100299R01.json
+++ b/revpi-hat-PR100299R01.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core 3+ 8GB",
     "pid": 299,

--- a/revpi-hat-PR100300R01.json
+++ b/revpi-hat-PR100300R01.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core 3+ 16GB",
     "pid": 300,

--- a/revpi-hat-PR100301R01.json
+++ b/revpi-hat-PR100301R01.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core 3+ 32GB",
     "pid": 301,

--- a/revpi-hat-PR100328R03.json
+++ b/revpi-hat-PR100328R03.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 0,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Flat",
     "pid": 328,

--- a/revpi-hat-PR100359R01.json
+++ b/revpi-hat-PR100359R01.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core S 8GB",
     "pid": 359,

--- a/revpi-hat-PR100360R01.json
+++ b/revpi-hat-PR100360R01.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core S 16GB",
     "pid": 360,

--- a/revpi-hat-PR100361R01.json
+++ b/revpi-hat-PR100361R01.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core S 32GB",
     "pid": 361,

--- a/revpi-hat-PR100365R00.json
+++ b/revpi-hat-PR100365R00.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core SE 8GB",
     "pid": 365,

--- a/revpi-hat-PR100366R00.json
+++ b/revpi-hat-PR100366R00.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core SE 16GB",
     "pid": 366,

--- a/revpi-hat-PR100367R00.json
+++ b/revpi-hat-PR100367R00.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "eeprom_data_version": 1,
     "vstr": "KUNBUS GmbH",
     "pstr": "RevPi Core SE 32GB",
     "pid": 367,

--- a/update-readme.py
+++ b/update-readme.py
@@ -8,8 +8,8 @@ readme = """# revpi-hat-eeprom-files
 
 Device specific JSON templates for RevPi HAT EEPROM generation
 
-| Device | Product Id | Product Revision | Devicetree Overlay |
-| ------ | ---------- | ---------------- | ------------------ |
+| Device | Product Id | Product Revision | Data Version | Devicetree Overlay |
+| ------ | ---------- | ---------------- | ------------ | ------------------ |
 """
 
 for template in revpi_hat_templates:
@@ -19,9 +19,10 @@ for template in revpi_hat_templates:
         name = template_data["pstr"]
         product_id = template_data["pid"] + 100000
         product_revision = template_data["prev"]
+        data_version = template_data["eeprom_data_version"]
         overlay = template_data["dtstr"]
 
-        readme += f"| [{name }]({template}) | PR{product_id} | R{product_revision:02} | {overlay} |\n"
+        readme += f"| [{name }]({template}) | PR{product_id} | R{product_revision:02} | {data_version} | {overlay} |\n"
 
 
 with open("README.md", "w") as f:


### PR DESCRIPTION
Implement support for https://github.com/RevolutionPi/revpi-hat-eeprom/pull/24