### PR TITLE
Added Core SE OEM version [REVPI-3018]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Device specific JSON templates for RevPi HAT EEPROM generation
 | [RevPi Core SE 8GB](./revpi-hat-PR100365R00.json) | PR100365 | R00 | 1 | revpi-core-se-2022 |
 | [RevPi Core SE 16GB](./revpi-hat-PR100366R00.json) | PR100366 | R00 | 1 | revpi-core-se-2022 |
 | [RevPi Core SE 32GB](./revpi-hat-PR100367R00.json) | PR100367 | R00 | 1 | revpi-core-se-2022 |
+| [RevPi Core SE 8GB (OEM)](./revpi-hat-PR100375R00.json) | PR100365 | R00 | 1 | revpi-core-se-2022 |

--- a/revpi-hat-PR100375R00.json
+++ b/revpi-hat-PR100375R00.json
@@ -1,0 +1,174 @@
+{
+    "version": 1,
+    "eeprom_data_version": 1,
+    "vstr": "KUNBUS GmbH",
+    "pstr": "RevPi Core SE 8GB (OEM)",
+    "pid": 365,
+    "prev": 0,
+    "pver": 100,
+    "dtstr": "revpi-core-se-2022",
+    "gpiobanks": [
+        {
+            "drive": "8mA",
+            "slew": "default",
+            "hysteresis": "default",
+            "gpios": [
+                {
+                    "gpio": 2,
+                    "fsel": "input",
+                    "pull": "none",
+                    "comment": [ "HAT EEPROM Write Protect (ID_WP)",
+				 "external pull-up" ]
+                },
+                {
+                    "gpio": 6,
+                    "fsel": "input",
+                    "pull": "down",
+                    "comment": [ "LED A1 red (LED.ARED)" ]
+                },
+                {
+                    "gpio": 14,
+                    "fsel": "alt0",
+                    "pull": "none",
+                    "comment": [ "UART TXD0 (PB_RS485.TX)",
+				 "earlycon" ]
+                },
+                {
+                    "gpio": 15,
+                    "fsel": "alt0",
+                    "pull": "up",
+                    "comment": [ "UART RXD0 (PB_RS485.RX)",
+				 "earlycon" ]
+                },
+                {
+                    "gpio": 16,
+                    "fsel": "input",
+                    "pull": "none",
+                    "comment": [ "LED Power red (LED.PWRRED)" ]
+                },
+                {
+                    "gpio": 17,
+                    "fsel": "input",
+                    "pull": "up",
+                    "comment": [ "UART RTS0 (PB_RS485.TX_EN)",
+				 "earlycon" ]
+                },
+                {
+                    "gpio": 22,
+                    "fsel": "alt4",
+                    "pull": "none",
+                    "comment": [ "ARM_TRST (JTAG_TRST)" ]
+                },
+                {
+                    "gpio": 23,
+                    "fsel": "alt4",
+                    "pull": "none",
+                    "comment": [ "ARM_RTCK (JTAG_RTCK)" ]
+                },
+                {
+                    "gpio": 24,
+                    "fsel": "alt4",
+                    "pull": "none",
+                    "comment": [ "ARM_TDO (JTAG_TDO)" ]
+                },
+                {
+                    "gpio": 25,
+                    "fsel": "alt4",
+                    "pull": "none",
+                    "comment": [ "ARM_TCK (JTAG_TCK)" ]
+                },
+                {
+                    "gpio": 26,
+                    "fsel": "alt4",
+                    "pull": "none",
+                    "comment": [ "ARM_TDI (JTAG_TDI)" ]
+                },
+                {
+                    "gpio": 27,
+                    "fsel": "alt4",
+                    "pull": "none",
+                    "comment": [ "ARM_TMS (JTAG_TMS)" ]
+                }
+            ]
+        },
+        {
+            "drive": "8mA",
+            "slew": "default",
+            "hysteresis": "default",
+            "gpios": [
+                {
+                    "gpio": 28,
+                    "fsel": "input",
+                    "pull": "down",
+                    "comment": [ "pibridge sniff 2a (PB_POS.2A)" ]
+                },
+                {
+                    "gpio": 29,
+                    "fsel": "input",
+                    "pull": "none",
+                    "comment": [ "pibridge sniff 2b (PB_POS.2B)",
+				 "external pull-down" ]
+                },
+                {
+                    "gpio": 30,
+                    "fsel": "input",
+                    "pull": "down",
+                    "comment": [ "LED A1 green (LED.AGRN)" ]
+                },
+                {
+                    "gpio": 31,
+                    "fsel": "input",
+                    "pull": "none",
+                    "comment": [ "LAN9514 nRESET (USB_CM.RUN)",
+				 "external pull-up" ]
+                },
+                {
+                    "gpio": 32,
+                    "fsel": "input",
+                    "pull": "down",
+                    "comment": [ "LED B1 green (LED.BGRN)" ]
+                },
+                {
+                    "gpio": 33,
+                    "fsel": "input",
+                    "pull": "down",
+                    "comment": [ "LED B1 red (LED.BRED)" ]
+                },
+                {
+                    "gpio": 41,
+                    "fsel": "input",
+                    "pull": "down",
+                    "comment": [ "UART RXD0/TXD0 termination (PB_RS485.TERM)" ]
+                },
+                {
+                    "gpio": 42,
+                    "fsel": "input",
+                    "pull": "none",
+                    "comment": [ "pibridge sniff 1a (PB_POS.1A)",
+				 "external pull-up" ]
+                },
+                {
+                    "gpio": 43,
+                    "fsel": "input",
+                    "pull": "none",
+                    "comment": [ "pibridge sniff 1b (PB_POS.1B)",
+				 "external pull-up" ]
+                },
+                {
+                    "gpio": 44,
+                    "fsel": "alt2",
+                    "pull": "none",
+                    "comment": [ "SDA1 (I2C_SDA)",
+				 "external pull-up" ]
+                },
+                {
+                    "gpio": 45,
+                    "fsel": "alt2",
+                    "pull": "none",
+                    "comment": [ "SCL1 (I2C_SCL)",
+				 "external pull-up" ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
The device description has to be added in order to use HAT EEPROM of OEM version of Core SE properly.